### PR TITLE
Fix #5 by managing branding separately in private repo

### DIFF
--- a/ansible/check_backend.yml
+++ b/ansible/check_backend.yml
@@ -170,17 +170,6 @@
       template: src={{ item }} dest={{ ANSIBLEDIR }}/{{ PBKDIR }}/{{ item | basename | regex_replace('\.j2$') }} mode=0644
       with_fileglob: [ '{{ ANSIBLEDIR }}/{{ PBKDIR }}/*.yml.j2' ]
 
-    - name: Enable backend WoD services
-      become: yes
-      become_user: root
-      systemd:
-        state: restarted
-        daemon_reload: yes
-        enabled: yes
-        name: "{{ item }}"
-      with_items:
-        - jupyterhub
-
     - name: Ensure that directory {{ STUDDIR }} exists
       become: yes
       become_user: root
@@ -249,6 +238,18 @@
       include_tasks: "{{ ANSIBLEPRIVDIR }}/check_backend.yml"
       when:
         - acj_path.rc == 0
+
+    # Done after private part, which may affect branding
+    - name: Enable backend WoD services
+      become: yes
+      become_user: root
+      systemd:
+        state: restarted
+        daemon_reload: yes
+        enabled: yes
+        name: "{{ item }}"
+      with_items:
+        - jupyterhub
 
     # Users management
     - name: Remove existing jupyterhub users

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -53,12 +53,12 @@ JPHUB: /opt/jupyterhub
 #
 # These variables are defined in ansible playbooks, do not change without knowing what you do
 #
-STUDDIR: "{{ ansible_env.STUDDIR }}"
-WODBEDIR: "{{ ansible_env.WODBEDIR }}"
-WODPRIVDIR: "{{ ansible_env.WODPRIVDIR }}"
-WODNOBO: "{{ ansible_env.WODNOBO }}"
-WODAPIDBDIR: "{{ ansible_env.WODAPIDBDIR }}"
-WODFEDIR: "{{ ansible_env.WODFEDIR }}"
+#STUDDIR: "{{ ansible_env.STUDDIR }}"
+#WODBEDIR: "{{ ansible_env.WODBEDIR }}"
+#WODPRIVDIR: "{{ ansible_env.WODPRIVDIR }}"
+#WODNOBO: "{{ ansible_env.WODNOBO }}"
+#WODAPIDBDIR: "{{ ansible_env.WODAPIDBDIR }}"
+#WODFEDIR: "{{ ansible_env.WODFEDIR }}"
 SCRIPTDIR: "{{ WODBEDIR }}/scripts"
 ANSIBLEDIR: "{{ WODBEDIR }}/ansible"
 # This is the predefined structure for a private repo

--- a/scripts/check-template.j2
+++ b/scripts/check-template.j2
@@ -7,6 +7,6 @@ TEMPLATE=WKSHP-Template
 source {{ SCRIPTDIR }}/wod.sh
 
 for u in `grep /home /etc/passwd | grep -vE 'syslog|{{ WODUSER }}' | cut -d: -f1`; do
-	rsync -av "{{ ansible_env.WODNOBO }}/$TEMPLATE" /home/$u
+	rsync -av "{{ WODNOBO }}/$TEMPLATE" /home/$u
 	chown $u:$u /home/$u/$TEMPLATE
 done

--- a/scripts/deliver.j2
+++ b/scripts/deliver.j2
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+WODPRIVINV=""
+ANSIBLEPRIVOPT=""
+
 source {{ SCRIPTDIR }}/wod.sh
 
 # Git doesn't collect file rights and we need to have correct ones here so forcing
@@ -19,4 +22,4 @@ done
 
 cd {{ ANSIBLEDIR }}
 
-ansible-playbook -i inventory --limit {{ PBKDIR }} -e "PBKDIR={{ PBKDIR }}" $ANSIBLEPRIVOPT check_backend.yml
+ansible-playbook -i inventory $WODPRIVINV --limit {{ PBKDIR }} -e "PBKDIR={{ PBKDIR }} WODUSER=$WODUSER WODBEDIR=$WODBEDIR WODNOBO=$WODNOBO WODPRIVNOBO=\"$WODPRIVDIR/notebooks\" WODPRIVDIR=$WODPRIVDIR WODAPIDBDIR=$WODAPIDBDIR WODFEDIR=$WODFEDIR STUDDIR=$STUDDIR" $ANSIBLEPRIVOPT check_$WODTYPE.yml

--- a/scripts/install_system.sh
+++ b/scripts/install_system.sh
@@ -36,6 +36,7 @@ cat > $SCRIPTDIR/wod.sh << EOF
 # This main dir is computed
 export WODBEDIR=`dirname $SCRIPTDIR`
 export WODUSER=$WODUSER
+export WODTYPE=$WODTYPE
 EOF
 cat >> $SCRIPTDIR/wod.sh << 'EOF'
 # These 3 dirs have fixed names by default that you can change in this file
@@ -45,11 +46,11 @@ export WODPRIVDIR=$PWODBEDIR/wod-private
 export ANSIBLEPRIVDIR=$WODPRIVDIR/ansible
 export WODAPIDBDIR=$PWODBEDIR/wod-api-db
 export WODFEDIR=$PWODBEDIR/wod-frontend
-WODANSOPT=""
+WODPRIVINV=""
 # Manages private inventory if any
 if [ -f $WODPRIVDIR/ansible/inventory ]; then
-	WODANSOPT="-i $WODPRIVDIR/ansible/inventory"
-	export WODANSOPT
+	WODPRIVINV="-i $WODPRIVDIR/ansible/inventory"
+	export WODPRIVINV
 fi
 EOF
 if [ $WODTYPE = "backend" ]; then
@@ -110,14 +111,16 @@ export ANSIBLEPRIVOPT="$ANSIBLEPRIVOPT"
 EOF
 export ANSIBLEPRIVOPT
 
-
+ANSPLAYOPT="PBKDIR=$PBKDIR WODUSER=$WODUSER WODBEDIR=$WODBEDIR WODNOBO=$WODNOBO WODPRIVNOBO=\"$WODPRIVDIR/notebooks\" WODPRIVDIR=$WODPRIVDIR WODAPIDBDIR=$WODAPIDBDIR WODFEDIR=$WODFEDIR STUDDIR=$STUDDIR"
+ANSPLAYOPT="-e $ANSPLAYOPT "
 if [ $WODTYPE = "backend" ]; then
 	ANSPLAYOPT="-e LDAPSETUP=0 -e APPMIN=0 -e APPMAX=0"
 elif [ $WODTYPE = "api-db" ] || [ $WODTYPE = "frontend" ]; then
 	ANSPLAYOPT="-e LDAPSETUP=0"
 fi
+
 # Automatic Installation script for the system 
-ansible-playbook -i inventory --limit $PBKDIR $ANSPLAYOPT $ANSIBLEPRIVOPT install_$WODTYPE.yml
+ansible-playbook -i inventory $WODPRIVINV --limit $PBKDIR $ANSPLAYOPT $ANSIBLEPRIVOPT install_$WODTYPE.yml
 
 if [ $WODTYPE = "api-db" ]; then
 	cd $WODAPIDBDIR
@@ -166,5 +169,5 @@ fi
 
 cd $SCRIPTDIR/../ansible
 
-ansible-playbook -i inventory --limit $PBKDIR -e "PBKDIR=$PBKDIR" $ANSIBLEPRIVOPT check_$WODTYPE.yml
+ansible-playbook -i inventory $WODPRIVINV --limit $PBKDIR -e "PBKDIR=$PBKDIR" $ANSIBLEPRIVOPT check_$WODTYPE.yml
 date

--- a/scripts/procmail-action.sh.j2
+++ b/scripts/procmail-action.sh.j2
@@ -118,7 +118,7 @@ if [ $action != "RESET" ]; then
 				ansible-playbook {{ ANSIBLEDIR }}/compile_scripts.yml -i {{ ANSIBLEDIR }}/inventory --limit {{ PBKDIR }} -e "STDID=$stdid COMPILE=\"$compile\"" $ANSIBLEPRIVOPT
 				if [ -f {{ ANSIBLEPRIVDIR }}/compile_scripts.yml ]; then
 					# YAML file not duplicated, just overload SCRIPTDIR var
-					ansible-playbook {{ ANSIBLEDIR }}/compile_scripts.yml -i {{ ANSIBLEDIR }}/inventory $WODANSOPT --limit {{ PBKDIR }} -e "STDID=$stdid COMPILE=\"$compile\" SCRIPTDIR={{ SCRIPTPRIVDIR }}" $ANSIBLEPRIVOPT
+					ansible-playbook {{ ANSIBLEDIR }}/compile_scripts.yml -i {{ ANSIBLEDIR }}/inventory $WODPRIVINV --limit {{ PBKDIR }} -e "STDID=$stdid COMPILE=\"$compile\" SCRIPTDIR={{ SCRIPTPRIVDIR }}" $ANSIBLEPRIVOPT
 				fi
 			fi
 			if [ -x "{{ SCRIPTDIR }}/create-$ws.sh" ]; then
@@ -130,7 +130,7 @@ if [ $action != "RESET" ]; then
 				{{ SCRIPTPRIVDIR }}/create-$ws.sh
 			fi
 			echo "Copying workshop $w content into target student dir $stddir"
-			ansible-playbook {{ ANSIBLEDIR }}/copy_folder.yml -i {{ ANSIBLEDIR }}/inventory $WODANSOPT --limit {{ PBKDIR }} -e "MODEWS=$MODEWS DIR=  WODUSER=$WODUSER WODBEDIR=$WODBEDIR WODNOBO=$WODNOBO WODPRIVNOBO="$WODPRIVDIR/notebooks" WODPRIVDIR=$WODPRIVDIR STUDDIR=$STUDDIR CHALLENGE=$w WORKSHOP=$ws STDID=$stdid" $ANSIBLEPRIVOPT --vault-password-file {{ ANSIBLEDIR }}/vault_secret
+			ansible-playbook {{ ANSIBLEDIR }}/copy_folder.yml -i {{ ANSIBLEDIR }}/inventory $WODPRIVINV --limit {{ PBKDIR }} -e "MODEWS=$MODEWS DIR=  WODUSER=$WODUSER WODBEDIR=$WODBEDIR WODNOBO=$WODNOBO WODPRIVNOBO=\"$WODPRIVDIR/notebooks\" WODPRIVDIR=$WODPRIVDIR STUDDIR=$STUDDIR CHALLENGE=$w WORKSHOP=$ws STDID=$stdid" $ANSIBLEPRIVOPT --vault-password-file {{ ANSIBLEDIR }}/vault_secret
 			if [ -x "{{ SCRIPTDIR }}/post-copy-$ws.sh" ]; then
 				echo "Perform post actions for workshop $w"
 				{{ SCRIPTDIR }}/post-copy-$ws.sh


### PR DESCRIPTION
- Restart jupyter service after private tasks for branding support
- Fix missing call to private inventory in deliver
- Rename WODANSOPT into WODPRIVINV and use where needed
- Fix ansible-playbook calls with more ansible variables definition (STUDDIR, WOD*, ...) removed from all.yml
- Fix WODNOBO usage in check-template.j2
- Manage WODTYPE with wod.sh