### PR TITLE
Various fixes for CentOS7 and evcxr

### DIFF
--- a/ansible/install_backend.yml
+++ b/ansible/install_backend.yml
@@ -431,6 +431,12 @@
         group: "{{ WODUSER }}"
         mode: 0751
 
+    - name: Deliver build scripts under /usr/local/bin
+      become: yes
+      become_user: root
+      template: src={{ item }} dest=/usr/local/bin/{{ item | basename | regex_replace('\.j2$') }} mode=0755
+      with_fileglob: [ '{{ SCRIPTDIR }}//build*.sh.j2' ]
+
     - name: Ensure Rust kernel is installed
       shell: . '{{ JPHUB }}/bin/activate' && "{{ WODBEDIR }}/evcxr_jupyter.{{ ansible_distribution }}-{{ ansible_distribution_major_version }}" --install
 

--- a/ansible/install_backend.yml
+++ b/ansible/install_backend.yml
@@ -561,7 +561,7 @@
     - name: Ensure dotnet kernel is installed
       become: yes
       become_user: root
-      command: dotnet-interactive jupyter install --path "{{ JPHUB }}/share/jupyter/kernels"
+      command: /usr/local/bin/dotnet-interactive jupyter install --path "{{ JPHUB }}/share/jupyter/kernels"
 
     - name: Ensure that directory "{{ JPHUB }}/etc/jupyterhub" exists
       file:

--- a/scripts/build_evcxr.sh.j2
+++ b/scripts/build_evcxr.sh.j2
@@ -19,7 +19,7 @@ fi
 . $HOME/.profile && cargo install cargo-script && cargo install evcxr_jupyter --no-default-features
 ansible-playbook {{ ANSIBLEDIR }}/distrib.yml
 DISTRIB=`cat $HOME/.mail/distrib`
-cp ~/.cargo/bin/evcxr_jupyter $SCRIPTDIR/evcxr_jupyter.$DISTRIB
+cp ~/.cargo/bin/evcxr_jupyter  {{ SCRIPTDIR }}/evcxr_jupyter.$DISTRIB
 if [ _"$v"  = _"" ] || [ $v -le 43 ]; then
 	/tmp/rust-init-$$.sh self uninstall
 	rm -f /tmp/rust-init-$$.sh

--- a/scripts/build_evcxr.sh.j2
+++ b/scripts/build_evcxr.sh.j2
@@ -11,7 +11,7 @@ mkdir -p $HOME/.mail
 source {{ SCRIPTDIR }}/wod.sh
 
 v=`rustc --version | awk '{ print $2 }' | cut -d. -f2`
-if [ _"$v"  = _"" ] || [ $v -le 43 ]; then
+if [ _"$v"  = _"" ] || [ $v -le 65 ]; then
 	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rust-init-$$.sh
 	chmod 755 /tmp/rust-init-$$.sh
 	/tmp/rust-init-$$.sh -y


### PR DESCRIPTION
CentOS7 can now be installed again as dotnet-interactive is use with a full path name.
Rocky 8 evcxr resquires rustc >= 1.65 and build script is now delivered.