### PR TITLE
Fix #83 by introducing the notion of multi-appliance

### DIFF
--- a/scripts/cleanup-WKSHP-Concourse101.sh.j2
+++ b/scripts/cleanup-WKSHP-Concourse101.sh.j2
@@ -2,7 +2,6 @@
 
 set -x
 
-export RTARGET={{ hostvars[inventory_hostname]['IP-WKSHP-Concourse101'] }}
 NAME=concourselab
 TMPDIR=/tmp/$NAME.$stdid.ret
 

--- a/scripts/cleanup-WKSHP-DataVisu101.sh.j2
+++ b/scripts/cleanup-WKSHP-DataVisu101.sh.j2
@@ -2,7 +2,6 @@
 
 set -x
 
-export RTARGET={{ hostvars[inventory_hostname]['IP-WKSHP-DataVisu101'] }}
 export NAME=datavisulab
 export TMPDIR=/tmp/$NAME.$stdid.ret
 

--- a/scripts/cleanup-WKSHP-ML101.sh.j2
+++ b/scripts/cleanup-WKSHP-ML101.sh.j2
@@ -2,7 +2,6 @@
 
 set -x
 
-export RTARGET={{ hostvars[inventory_hostname]['IP-WKSHP-ML101'] }}
 export NAME=mllab
 export TMPDIR=/tmp/$NAME.$stdid.ret
 

--- a/scripts/cleanup-WKSHP-Spark101.sh.j2
+++ b/scripts/cleanup-WKSHP-Spark101.sh.j2
@@ -2,7 +2,6 @@
 
 set -x
 
-export RTARGET={{ hostvars[inventory_hostname]['IP-WKSHP-Spark101'] }}
 export NAME=sparklab
 export TMPDIR=/tmp/$NAME.$stdid.ret
 

--- a/scripts/create-WKSHP-Ansible101.sh.j2
+++ b/scripts/create-WKSHP-Ansible101.sh.j2
@@ -4,7 +4,6 @@ set -x
 
 source {{ SCRIPTDIR }}/functions.sh
 
-export RTARGET={{ hostvars[inventory_hostname]['IP-WKSHP-Ansible101'] }}
 # Start by cleaning up stuff - do it early as after we setup .ssh content
 {{ SCRIPTDIR }}/reset-$ws.sh
 {{ SCRIPTDIR }}/create-appliance.sh

--- a/scripts/create-WKSHP-Concourse101.sh.j2
+++ b/scripts/create-WKSHP-Concourse101.sh.j2
@@ -4,7 +4,6 @@ set -x
 
 source {{ SCRIPTDIR }}/functions.sh
 
-export RTARGET={{ hostvars[inventory_hostname]['IP-WKSHP-Concourse101'] }}
 # Start by cleaning up stuff - do it early as after we setup .ssh content
 {{ SCRIPTDIR }}/reset-$ws.sh
 {{ SCRIPTDIR }}/create-appliance.sh

--- a/scripts/create-WKSHP-DataVisu101.sh.j2
+++ b/scripts/create-WKSHP-DataVisu101.sh.j2
@@ -3,8 +3,6 @@
 set -x
 source {{ SCRIPTDIR }}/functions.sh
 
-export RTARGET={{ hostvars[inventory_hostname]['IP-WKSHP-DataVisu101'] }}
-
 # Start by cleaning up stuff - do it early as after we setup .ssh content
 {{ SCRIPTDIR }}//reset-$ws.sh
 {{ SCRIPTDIR }}//create-appliance.sh

--- a/scripts/create-WKSHP-Docker101.sh.j2
+++ b/scripts/create-WKSHP-Docker101.sh.j2
@@ -4,7 +4,6 @@ set -x
 
 source {{ SCRIPTDIR }}/functions.sh
 
-export RTARGET={{ hostvars[inventory_hostname]['IP-WKSHP-Docker101'] }}
 # Start by cleaning up stuff - do it early as after we setup .ssh content
 {{ SCRIPTDIR }}/reset-$ws.sh
 {{ SCRIPTDIR }}/create-appliance.sh

--- a/scripts/create-WKSHP-ML101.sh.j2
+++ b/scripts/create-WKSHP-ML101.sh.j2
@@ -4,7 +4,6 @@ set -x
 
 source {{ SCRIPTDIR }}/functions.sh
 
-export RTARGET={{ hostvars[inventory_hostname]['IP-WKSHP-ML101'] }}
 # Start by cleaning up stuff - do it early as after we setup .ssh content
 {{ SCRIPTDIR }}/reset-$ws.sh
 {{ SCRIPTDIR }}/create-appliance.sh

--- a/scripts/create-WKSHP-Podman101.sh.j2
+++ b/scripts/create-WKSHP-Podman101.sh.j2
@@ -4,7 +4,6 @@ set -x
 
 source {{ SCRIPTDIR }}/functions.sh
 
-export RTARGET={{ hostvars[inventory_hostname]['IP-WKSHP-Podman101'] }}
 # Start by cleaning up stuff - do it early as after we setup .ssh content
 {{ SCRIPTDIR }}/reset-$ws.sh
 {{ SCRIPTDIR }}/create-appliance.sh

--- a/scripts/create-WKSHP-Podman201.sh.j2
+++ b/scripts/create-WKSHP-Podman201.sh.j2
@@ -4,7 +4,6 @@ set -x
 
 source {{ SCRIPTDIR }}/functions.sh
 
-export RTARGET={{ hostvars[inventory_hostname]['IP-WKSHP-Podman201'] }}
 # Start by cleaning up stuff - do it early as after we setup .ssh content
 {{ SCRIPTDIR }}/reset-$ws.sh
 {{ SCRIPTDIR }}/create-appliance.sh

--- a/scripts/create-WKSHP-Spark101.sh.j2
+++ b/scripts/create-WKSHP-Spark101.sh.j2
@@ -4,7 +4,6 @@ set -x
 
 source {{ SCRIPTDIR }}/functions.sh
 
-export RTARGET={{ hostvars[inventory_hostname]['IP-WKSHP-Spark101'] }}
 # Start by cleaning up stuff - do it early as after we setup .ssh content
 {{ SCRIPTDIR }}/reset-$ws.sh
 {{ SCRIPTDIR }}/create-appliance.sh

--- a/scripts/create-WKSHP-StackStorm101.sh.j2
+++ b/scripts/create-WKSHP-StackStorm101.sh.j2
@@ -2,6 +2,5 @@
 
 set -x
 
-export RTARGET={{ hostvars[inventory_hostname]["IP-WKSHP-StackStorm101"] }}
 {{ SCRIPTDIR }}/create-appliance.sh
 ssh $RTARGET "echo $randompw | sudo htpasswd -i /etc/st2/htpasswd student$stdid"

--- a/scripts/functions.sh.j2
+++ b/scripts/functions.sh.j2
@@ -29,15 +29,16 @@ get_session_token() {
 get_workshop_id() {
 
 	id=0
-	for i in `curl -s --header "x-access-token:$accessToken" --header "Content-Type: application/json" "$WODFEAPIURL/workshops" | jq -r '.[].id'`; do
-		name=`curl -s --header "x-access-token:$accessToken"  --header "Content-Type: application/json" "$WODFEAPIURL/workshops/$i" | jq .notebook | sed 's/"//g'`
-		if [ _"$name" = _"$1" ]; then
-			id=$i
-			break
+	id=`curl -s --header "x-access-token:$accessToken" --header "Content-Type: application/json" "$WODFEAPIURL/workshops" | jq -r '.[] | .notebook,.id' | grep -A 1 -E "^$1$" | tail -1`
+	#for i in `curl -s --header "x-access-token:$accessToken" --header "Content-Type: application/json" "$WODFEAPIURL/workshops" | jq -r '.[].id'`; do
+		#name=`curl -s --header "x-access-token:$accessToken"  --header "Content-Type: application/json" "$WODFEAPIURL/workshops/$i" | jq .notebook | sed 's/"//g'`
+		#if [ _"$name" = _"$1" ]; then
+			#id=$i
+			#break
 
-		fi
-	done
-	if [ $id = 0 ]; then
+		#fi
+	#done
+	if [ _"$id" = _"" ]; then
 		echo "Workshop ID not found remotely for $1"
 		exit -1
 	fi
@@ -68,6 +69,20 @@ get_reset_status() {
 get_beta_status() {
 
         ret=`curl -s --header "x-access-token:$accessToken" --header "Content-Type: application/json" "$WODFEAPIURL/workshops/$1" | jq -r '.beta'`
+        echo "$ret"
+}
+
+# This function returns the status of the mono-appliance boolean for the workshop id given as parameter
+get_monoappliance_status() {
+
+        ret=`curl -s --header "x-access-token:$accessToken" --header "Content-Type: application/json" "$WODFEAPIURL/workshops/$1" | jq -r '.monoappliance'`
+        echo "$ret"
+}
+
+# This function returns the status of the multi-appliance boolean for the workshop id given as parameter
+get_multiappliance_status() {
+
+        ret=`curl -s --header "x-access-token:$accessToken" --header "Content-Type: application/json" "$WODFEAPIURL/workshops/$1" | jq -r '.multiappliance'`
         echo "$ret"
 }
 
@@ -106,6 +121,19 @@ get_range_max() {
 
 	ret=`curl -s --header "x-access-token:$accessToken" --header "Content-Type: application/json" "$WODFEAPIURL/workshops/$1" | jq -r '.range[1]'`
 	echo "$ret"
+}
+
+# This function returns the base IP address of the appliance related to the workshop given as parameter
+get_appliance_baseip() {
+	baseip=`grep IP-$1 {{ ANSIBLEPRIVDIR }}/group_vars/{{ PBKDIR }} | cut -d: -f2 | sed 's/[ 	]*//'`
+	if [ _"$baseip" = _"" ]; then
+		baseip=`grep IP-$1 {{ ANSIBLEDIR }}/group_vars/{{ PBKDIR }} | cut -d: -f2 | sed 's/[ 	]*//'`
+		if [ _"$baseip" = _"" ]; then
+			echo "Unable to find the the appliance base IP for $1"
+			exit -1
+		fi
+	fi
+	echo "$baseip"
 }
 
 # This function updates the LDAP passwd with $randompw for the student under management (using $stdid)

--- a/scripts/procmail-action.sh.j2
+++ b/scripts/procmail-action.sh.j2
@@ -79,6 +79,24 @@ fi
 export w
 export ws
 export wid=`get_workshop_id $w`
+#
+# Is it a multi-appliance setup ?
+multiappliance=`get_multiappliance_status $wid`
+monoappliance=`get_monoappliance_status $wid`
+if [ _"`get_multiappliance_status $wid`" != _"false" ]; then
+	APPMINVALUE=`get_range_min $wid`
+	delta=$(($stdid-$APPMINVALUE))
+	baseip=`get_appliance_baseip $w`
+	basedigit=`echo $baseip | cut -d'.' -f4`
+	netip=`echo $baseip | cut -d'.' -f1-3`
+	ip=$(($basedigit+$delta))
+	export RTARGET="$netip.$ip"
+else
+	if [ _"`get_monoappliance_status $wid`" != _"false" ]; then
+		export RTARGET=`get_appliance_baseip $w`
+	fi
+	# If no appliance, we do not define RTARGET on purpose
+fi
 
 # Handle CREATE and CLEANUP first
 if [ $action != "RESET" ]; then
@@ -110,6 +128,7 @@ if [ $action != "RESET" ]; then
 
 		if [ "$action" = "CREATE" ]; then
 			erase_student
+			# compile flag is a STRING not a boolean
 			compile=`get_compile_status $wid`
 			if [ _"$compile" = _"null" ]; then
 				compile=""
@@ -135,11 +154,12 @@ if [ $action != "RESET" ]; then
 				fi
 			fi
 			if [ -x "{{ SCRIPTDIR }}/create-$ws.sh" ]; then
-				echo "Setup workshop $w Backend"
+				echo "Setup workshop $w appliance"
+
 				{{ SCRIPTDIR }}/create-$ws.sh
 			fi
 			if [ -x "{{ SCRIPTPRIVDIR }}/create-$ws.sh" ]; then
-				echo "Setup private workshop $w Backend"
+				echo "Setup private workshop $w appliance"
 				{{ SCRIPTPRIVDIR }}/create-$ws.sh
 			fi
 			echo "Copying workshop $w content into target student dir $stddir"
@@ -161,7 +181,7 @@ if [ $action != "RESET" ]; then
 		dbstdid=$((stdid+{{ BASESTDID }}))
 
 		# Instead do 2 API calls here, one for passwd change, one for status change
-		##Update Password
+		# Update Password
 		curl --header "x-access-token:$accessToken" --header "Content-Type: application/json" \
 			 --request PUT \
 			 --data '{"password":"'$randompw'"}' \

--- a/scripts/reset-WKSHP-Ansible101.sh.j2
+++ b/scripts/reset-WKSHP-Ansible101.sh.j2
@@ -2,7 +2,6 @@
 
 set -x
 
-export RTARGET={{ hostvars[inventory_hostname]['IP-WKSHP-Ansible101'] }}
 {{ SCRIPTDIR }}/reset-appliance.sh
 
 # Cleanup

--- a/scripts/reset-WKSHP-Concourse101.sh.j2
+++ b/scripts/reset-WKSHP-Concourse101.sh.j2
@@ -2,7 +2,6 @@
 
 set -x
 
-export RTARGET={{ hostvars[inventory_hostname]['IP-WKSHP-Concourse101'] }}
 {{ SCRIPTDIR }}/reset-appliance.sh
 
 NAME=concourselab

--- a/scripts/reset-WKSHP-DataVisu101.sh.j2
+++ b/scripts/reset-WKSHP-DataVisu101.sh.j2
@@ -2,8 +2,7 @@
 
 set -x
 
-export RTARGET={{ hostvars[inventory_hostname]['IP-WKSHP-DataVisu101'] }}
-/home/jupyter/jupyter-procmail/scripts/reset-appliance.sh
+{{ SCRIPTDIR }}/reset-appliance.sh
 
 NAME=datavisulab
 TMPDIR=/tmp/$NAME.$stdid

--- a/scripts/reset-WKSHP-Docker101.sh.j2
+++ b/scripts/reset-WKSHP-Docker101.sh.j2
@@ -2,7 +2,6 @@
 
 set -x
 
-export RTARGET={{ hostvars[inventory_hostname]['IP-WKSHP-Docker101'] }}
 {{ SCRIPTDIR }}/reset-appliance.sh
 
 NAME=dockerlab

--- a/scripts/reset-WKSHP-ML101.sh.j2
+++ b/scripts/reset-WKSHP-ML101.sh.j2
@@ -2,7 +2,6 @@
 
 set -x
 
-export RTARGET={{ hostvars[inventory_hostname]['IP-WKSHP-ML101'] }}
 {{ SCRIPTDIR }}/reset-appliance.sh
 
 NAME=mllab

--- a/scripts/reset-WKSHP-Podman101.sh.j2
+++ b/scripts/reset-WKSHP-Podman101.sh.j2
@@ -2,7 +2,6 @@
 
 set -x
 
-export RTARGET={{ hostvars[inventory_hostname]['IP-WKSHP-Podman101'] }}
 {{ SCRIPTDIR }}/reset-appliance.sh
 
 NAME=podmanlab

--- a/scripts/reset-WKSHP-Podman201.sh.j2
+++ b/scripts/reset-WKSHP-Podman201.sh.j2
@@ -2,7 +2,6 @@
 
 set -x
 
-export RTARGET={{ hostvars[inventory_hostname]['IP-WKSHP-Podman201'] }}
 {{ SCRIPTDIR }}/reset-appliance.sh
 
 NAME=podmanlab

--- a/scripts/reset-WKSHP-Spark101.sh.j2
+++ b/scripts/reset-WKSHP-Spark101.sh.j2
@@ -2,7 +2,6 @@
 
 set -x
 
-export RTARGET={{ hostvars[inventory_hostname]['IP-WKSHP-Spark101'] }}
 {{ SCRIPTDIR }}/reset-appliance.sh
 
 NAME=sparklab

--- a/scripts/reset-WKSHP-StackStorm101.sh.j2
+++ b/scripts/reset-WKSHP-StackStorm101.sh.j2
@@ -2,7 +2,6 @@
 
 set -x
 
-export RTARGET={{ hostvars[inventory_hostname]["IP-WKSHP-StackStorm101"] }}
 {{ SCRIPTDIR }}/reset-appliance.sh
 
 # That Workshop also needs another passwd reset

--- a/scripts/setup-appliance.sh.j2
+++ b/scripts/setup-appliance.sh.j2
@@ -39,69 +39,92 @@ export accessToken=`get_session_token`
 # If that doesn't fail, then export the workshop name
 export wid=`get_workshop_id $w`
 #export WKSHP=`echo $w | sed 's/WKSHP-//' | tr [a-z] [A-Z]`
-export RTARGET=`grep IP-$w {{ ANSIBLEPRIVDIR }}/group_vars/{{ PBKDIR }} | cut -d: -f2 | sed 's/[ 	]*//'`
-if [ _"$RTARGET" = _"" ]; then
-	export RTARGET=`grep IP-$w {{ ANSIBLEDIR }}/group_vars/{{ PBKDIR }} | cut -d: -f2 | sed 's/[ 	]*//'`
-	if [ _"$RTARGET" = _"" ]; then
-		echo "Unable to find the RTARGET for $w"
-		exit -1
-	fi
-fi
-export APPMIN=`get_range_min $wid`
+
+# Is it a multi-appliance setup ?
+multiappliance=`get_multiappliance_status $wid`
+monoappliance=`get_monoappliance_status $wid`
+echo "Searching for appliance base IP"
+baseip=`get_appliance_baseip $w`
+export APPMINVALUE=`get_range_min $wid`
+export APPMIN=$APPMINVALUE
 max=`get_range_max $wid`
 export APPMAX=$(($max+1))
 
-if [ -x "{{ SCRIPTDIR }}/setup-pre-$w.sh" ]; then
-	echo "Setup Appliance for Workshop $w by executing {{ SCRIPTDIR }}/setup-pre-$w.sh at `date`"
-	{{ SCRIPTDIR }}/setup-pre-$w.sh
-	echo "End of Appliance pre setup for Workshop $w at `date`"
-fi
-if [ -x "{{ SCRIPTPRIVDIR }}/setup-pre-$w.sh" ]; then
-	echo "Setup Appliance for private Workshop $w by executing {{ SCRIPTPRIVDIR }}/setup-pre-$w.sh at `date`"
-	{{ SCRIPTPRIVDIR }}/setup-pre-$w.sh
-	echo "End of Appliance pre setup for Workshop $w at `date`"
-fi
+basedigit=`echo $baseip | cut -d'.' -f4`
+netip=`echo $baseip | cut -d'.' -f1-3`
 
-echo "Setup Global Appliance for Workshop $w at `date`"
-{{ SCRIPTDIR }}/setup-globalappliance.sh
-echo "End of Global Appliance setup for Workshop $w at `date`"
-
-if [ -x {{ SCRIPTPRIVDIR }}/setup-globalappliance.sh ]; then
-	echo "Setup Global Appliance for private Workshop $w at `date`"
-	{{ SCRIPTPRIVDIR }}/setup-globalappliance.sh
-	echo "End of Global Appliance setup for private Workshop $w at `date`"
+# Loop on the number of appliances we need - generally 1 except if multi-appliance is set
+if [ _"`get_multiappliance_status $wid`" != _"false" ]; then
+	capacity=$(($APPMAX-$APPMIN))
+	lastdigit=$(($basedigit + $capacity -1))
+else
+	if [ _"`get_monoappliance_status $wid`" != _"false" ]; then
+		lastdigit=$basedigit
+	else
+		echo "To setup an appliance for $w, you need to declare a variable as"
+		echo "IP-$w: x.y.z.t in the file {{ ANSIBLEDIR }}/group_vars/{{ PBKDIR }}"
+		exit -1
+	fi
 fi
 
-if [ -x "{{ SCRIPTDIR }}/setup-post-$w.sh" ]; then
-	echo "Setup Appliance for Workshop $w by executing {{ SCRIPTDIR }}/setup-post-$w.sh at `date`"
-	{{ SCRIPTDIR }}/setup-post-$w.sh
-	echo "End of Appliance post setup for Workshop $w at `date`"
-fi
-if [ -x "{{ SCRIPTPRIVDIR }}/setup-post-$w.sh" ]; then
-	echo "Setup Appliance for private Workshop $w by executing {{ SCRIPTPRIVDIR }}/setup-post-$w.sh at `date`"
-	{{ SCRIPTPRIVDIR }}/setup-post-$w.sh
-	echo "End of Appliance post setup for Workshop $w at `date`"
-fi
+j=0
+for i in $(seq $basedigit $lastdigit); do
+	if [ _"`get_multiappliance_status $wid`" != _"false" ]; then
+		export APPMIN=$(($APPMINVALUE+$j))
+		export APPMAX=$(($APPMIN+1))
+		j=$((j+1))
+	fi
+	export RTARGET="$netip.$i"
+	if [ -x "{{ SCRIPTDIR }}/setup-pre-$w.sh" ]; then
+		echo "Setup Appliance for Workshop $w by executing {{ SCRIPTDIR }}/setup-pre-$w.sh at `date`"
+		{{ SCRIPTDIR }}/setup-pre-$w.sh
+		echo "End of Appliance pre setup for Workshop $w at `date`"
+	fi
+	if [ -x "{{ SCRIPTPRIVDIR }}/setup-pre-$w.sh" ]; then
+		echo "Setup Appliance for private Workshop $w by executing {{ SCRIPTPRIVDIR }}/setup-pre-$w.sh at `date`"
+		{{ SCRIPTPRIVDIR }}/setup-pre-$w.sh
+		echo "End of Appliance pre setup for Workshop $w at `date`"
+	fi
 
-if [ -x "{{ SCRIPTDIR }}/setup-$w.sh" ]; then
-	echo "Setup Appliance for Workshop $w by executing remotely {{ SCRIPTDIR }}/setup-$w.sh at `date`"
-	TMPDIR=/tmp/sa.$$
-	ssh $RTARGET mkdir -p $TMPDIR
-	scp {{ SCRIPTDIR }}/setup-$w.sh $RTARGET:$TMPDIR/
-	# We have to pass the Workshop name to have it remotely as well as the $w variable
-	ssh $RTARGET "$TMPDIR/setup-$w.sh $w"
-	ssh $RTARGET rm -rf $TMPDIR
-	echo "End of Appliance setup for Workshop $w at `date`"
-fi
+	echo "Setup Global Appliance for Workshop $w at `date`"
+	{{ SCRIPTDIR }}/setup-globalappliance.sh
+	echo "End of Global Appliance setup for Workshop $w at `date`"
 
-if [ -x "{{ SCRIPTPRIVDIR }}/setup-$w.sh" ]; then
-	echo "Setup Appliance for private Workshop $w by executing remotely {{ SCRIPTPRIVDIR }}/setup-$w.sh at `date`"
-	TMPDIR=/tmp/sa.$$
-	ssh $RTARGET mkdir -p $TMPDIR
-	scp {{ SCRIPTPRIVDIR }}/setup-$w.sh $RTARGET:$TMPDIR/
-	ssh $RTARGET "$TMPDIR/setup-$w.sh $w"
-	ssh $RTARGET rm -rf $TMPDIR
-	echo "End of Appliance setup for private Workshop $w at `date`"
-fi
+	if [ -x {{ SCRIPTPRIVDIR }}/setup-globalappliance.sh ]; then
+		echo "Setup Global Appliance for private Workshop $w at `date`"
+		{{ SCRIPTPRIVDIR }}/setup-globalappliance.sh
+		echo "End of Global Appliance setup for private Workshop $w at `date`"
+	fi
 
+	if [ -x "{{ SCRIPTDIR }}/setup-post-$w.sh" ]; then
+		echo "Setup Appliance for Workshop $w by executing {{ SCRIPTDIR }}/setup-post-$w.sh at `date`"
+		{{ SCRIPTDIR }}/setup-post-$w.sh
+		echo "End of Appliance post setup for Workshop $w at `date`"
+	fi
+	if [ -x "{{ SCRIPTPRIVDIR }}/setup-post-$w.sh" ]; then
+		echo "Setup Appliance for private Workshop $w by executing {{ SCRIPTPRIVDIR }}/setup-post-$w.sh at `date`"
+		{{ SCRIPTPRIVDIR }}/setup-post-$w.sh
+		echo "End of Appliance post setup for Workshop $w at `date`"
+	fi
 
+	if [ -x "{{ SCRIPTDIR }}/setup-$w.sh" ]; then
+		echo "Setup Appliance for Workshop $w by executing remotely {{ SCRIPTDIR }}/setup-$w.sh at `date`"
+		TMPDIR=/tmp/sa.$$
+		ssh $RTARGET mkdir -p $TMPDIR
+		scp {{ SCRIPTDIR }}/setup-$w.sh $RTARGET:$TMPDIR/
+		# We have to pass the Workshop name to have it remotely as well as the $w variable
+		ssh $RTARGET "$TMPDIR/setup-$w.sh $w"
+		ssh $RTARGET rm -rf $TMPDIR
+		echo "End of Appliance setup for Workshop $w at `date`"
+	fi
+
+	if [ -x "{{ SCRIPTPRIVDIR }}/setup-$w.sh" ]; then
+		echo "Setup Appliance for private Workshop $w by executing remotely {{ SCRIPTPRIVDIR }}/setup-$w.sh at `date`"
+		TMPDIR=/tmp/sa.$$
+		ssh $RTARGET mkdir -p $TMPDIR
+		scp {{ SCRIPTPRIVDIR }}/setup-$w.sh $RTARGET:$TMPDIR/
+		ssh $RTARGET "$TMPDIR/setup-$w.sh $w"
+		ssh $RTARGET rm -rf $TMPDIR
+		echo "End of Appliance setup for private Workshop $w at `date`"
+	fi
+done


### PR DESCRIPTION
- Remove mention of RTARGET in VERB-scripts as expoerted by callers
- Adds get_appliance_baseip function to return the IP address of either the appliance (mono-appliance) or the base of the range (multi-appliance). It requires workshop name not id
- Adds get_multiappliance_status boolean function to get whether we are in a mono or multi appliance context
- Adapt procmail-action to compute the RTARGET exported variable based on whether we are in mono appliance mode (just the baseip) or in multi appliance mode (baseip + stdid delta)
- Adapt setup_appliance to create either multiple users in a range on a mono appliance or a single user (id increasing) in multi appliance
- Also add the notion of mono-appliance to detect whether a workshop needs one or not. Mandatory now for procmail-action.
- Remove loop on workshops to find id, by using a better jq expression


This also requires modifications on wod-private and wod-api-db